### PR TITLE
Make Docker images unique

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
       run: docker login docker.pkg.github.com -u arikkfir -p ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Image
-      run: docker build --file=build/Dockerfile --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/service:${GITHUB_SHA} .
+      run: docker build --file=build/Dockerfile --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REPOSITORY}:${GITHUB_SHA} .
 
     - name: Push Image
-      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/service:${GITHUB_SHA}
+      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REPOSITORY}:${GITHUB_SHA}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
       run: docker login docker.pkg.github.com -u arikkfir -p ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Image
-      run: docker build --file=build/Dockerfile --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REPOSITORY}:${GITHUB_SHA} .
+      run: docker build --file=build/Dockerfile --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/gate:${GITHUB_SHA} .
 
     - name: Push Image
-      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/${GITHUB_REPOSITORY}:${GITHUB_SHA}
+      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/gate:${GITHUB_SHA}


### PR DESCRIPTION
According to GitHub, Docker images are user-level unique, rather than repository-level unique.
While this is odd (since the repository name is part of the image name), it has been confirmed
by GitHub.

Therefor, adding the repository name as the actual image name, even though that duplicates it.

- https://wouterdeschuyter.be/blog/github-package-registry-cannot-find-package-version-with-version-id-please-ensure-that-your-token-has-repo-scopes